### PR TITLE
Set a default value of CORS hostname

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.groovy.template.check-template-location=false
 #spring.session.jdbc.initialize-schema=always
 #spring.session.store-type=jdbc
 #spring.h2.console.enabled=true
+
+cors-hostname=localhost


### PR DESCRIPTION
후속 작업의 편의성을 위해 설정 파일에  `cors-hostname` 기본값을 지정합니다. 참고: #6 이전에 머지 되어야 합니다.